### PR TITLE
Making the trash-icon visible

### DIFF
--- a/styles/inputfields.css
+++ b/styles/inputfields.css
@@ -257,3 +257,12 @@
 .InputfieldRenderValueMode .InputfieldButton {
 	display: none; 
 }
+
+/****************************************************************************
+ * Repeater Field
+ *
+ */
+
+.InputfieldRepeater .InputfieldStateToggle.ui-state-error .InputfieldRepeaterTrash {
+	background-image: url('JqueryUI/images/ui-icons-dark.png');
+	}


### PR DESCRIPTION
Makes the trash-icon visible (dark) on label-hover on repeater-fields. Otherwise everything is white, which somehow confuses the user.
